### PR TITLE
Update apollo-link-context.md

### DIFF
--- a/docs/source/api/link/apollo-link-context.md
+++ b/docs/source/api/link/apollo-link-context.md
@@ -5,7 +5,7 @@ description: Easily set a context on your operation, which is used by other link
 
 ## Overview
 
-The `setContext` function accepts a function that returns either an object or a promise, which then returns an object to set the new context of a request. It receives two arguments: the GraphQL request being executed, and the previous context. This link makes it easy to perform the asynchronous lookup of things like authentication tokens and more.
+The `setContext` function accepts a function that returns either an object or a promise, which then returns an object to be merged with the context of a request. It receives two arguments: the GraphQL request being executed, and the previous context. This link makes it easy to perform the asynchronous lookup of things like authentication tokens and more.
 
 ```js
 import { setContext } from "@apollo/client/link/context";


### PR DESCRIPTION
Correct language with regard to behavior of `setContext` link. The returned object doesn't become the new context, it's merged with the current context:

https://github.com/apollographql/apollo-client/blob/main/src/link/utils/createOperation.ts#L8

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
